### PR TITLE
Updated JavaDocument.java - Marked useSpacesForIndentation as static & Used the diamond operator (<>) for the HashSet<String>

### DIFF
--- a/robocode.ui.editor/src/main/java/net/sf/robocode/ui/editor/JavaDocument.java
+++ b/robocode.ui.editor/src/main/java/net/sf/robocode/ui/editor/JavaDocument.java
@@ -59,7 +59,7 @@ public class JavaDocument extends StyledDocument {
 	private boolean isAutoIndentEnabled = true;
 
 	/** Flag defining if spaces must be used for indentation; otherwise tabulation characters are being used */
-	private final boolean useSpacesForIndentation = false;
+	private static final boolean useSpacesForIndentation = false;
 
 	/** Tab size (column width) */
 	private int tabSize = 4; // Default is every 4th column
@@ -68,7 +68,7 @@ public class JavaDocument extends StyledDocument {
 	private static final String QUOTE_DELIMITERS = "\"'";
 
 	/** Java keywords */
-	private static final Set<String> KEYWORDS = new HashSet<String>(
+	private static final Set<String> KEYWORDS = new HashSet<>(
 			Arrays.asList(
 					"abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue",
 					"default", "do", "double", "else", "enum", "extends", "final", "finally", "float", "for", "goto", "if",


### PR DESCRIPTION
By making 'useSpacesForIndentation' static final, it becomes a constant associated with the class rather than any instance.

Diamond Operator(<>) allows Java to infer the generic type String without you needing to specify it again.